### PR TITLE
RNMT-1883 Upgrade FingerPrint Plugin to fix encrypt error on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -8,7 +8,7 @@
     <description>Cordova FingerPrint Plugin</description>
     <license>Apache 2.0</license>
     <keywords>cordova,device</keywords>
-    <dependency id="cordova-plugin-android-fingerprint-auth" url="https://github.com/OutSystems/cordova-plugin-android-fingerprint-auth.git#0.3.0-OS" />
+    <dependency id="cordova-plugin-android-fingerprint-auth" url="https://github.com/OutSystems/cordova-plugin-android-fingerprint-auth.git#1.4.4" />
     <dependency id="cordova-plugin-touchid" url="https://github.com/OutSystems/cordova-plugin-touchid.git#0.4.0-OS" />
      <engines>
         <engine name="cordova" version=">=3.0.0" />

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -57,7 +57,7 @@ FingerPrint.prototype.authenticate = function (successCallback, errorCallback,ob
 			errorCallback(error);
     };
     // if the device is android call th FingerprintAuth plugin
-    if(cordova.platformId === "android"){FingerprintAuth.show(object, successCbFingerPrintAuth, errorCbFingerPrintAuth);}
+    if(cordova.platformId === "android"){FingerprintAuth.encrypt(object, successCbFingerPrintAuth, errorCbFingerPrintAuth);}
     // if the device is ios call the touchid plugin 
     if(cordova.platformId === "ios")touchid.authenticate(successCallback, errorCallback, object.dialogMessage);
 };


### PR DESCRIPTION
The latest versions of cordova-plugin-android-fingerprint-auth already contains the fix for the issue reported.  It was done the update this plugin and update the dependencies and API on the cordova-plugin-fingerprint wrapper.