### PR TITLE
RMET-1535 TouchID Plugin - Change android:exported true to false

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS" />
+        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#fix/RMET-1535/remove-exported-true" />
     </platform>
 
     <platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#fix/RMET-1535/remove-exported-true" />
+        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS1" />
     </platform>
 
     <platform name="ios">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
In this PR we update the dependency to [cordova-plugin-fingerprint-aio](https://github.com/OutSystems/cordova-plugin-fingerprint-aio). This changes the `android:exported` element of the `BiometricActivity` activity from `true` to `false` since it doesn't need to be true. This activity has no intent filters and isn't suppose to be called from any other app so this element can be set to false.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1533 and https://outsystemsrd.atlassian.net/browse/RMET-1535


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Built with MABS 7 and MABS 8. Tested the plugin in both versions.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
