### PR TITLE
RMET-1588 Touch ID Plugin - Surround access to mCallbackContext with null check

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS2" />
+        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#fix/RMET-1588/avoid-null-point-on-resume" />
     </platform>
 
     <platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#fix/RMET-1588/avoid-null-point-on-resume" />
+        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS3" />
     </platform>
 
     <platform name="ios">


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

In memory shortage cases, where the system kills the app silently in the background, mCallbackContext can be null and this will result in a NullPointerException. This PR updates the dependency to `fingerprint-aio` to avoid that.


## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1588

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS builds and tested in Pixel 3 running Android 12.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
