### PR TITLE
RMET-1683 TouchID Plugin - Fix bug on obtaining Message for prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The changes documented here do not include those from the original repository.
+
+## [Unreleased]
+
+## 28-06-2022
+- Fixed bug for message description in iOS (https://outsystemsrd.atlassian.net/browse/RMET-1683).

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -50,7 +50,7 @@ FingerPrint.prototype.authenticate = function (successCallback, errorCallback,ob
     // if the device is android call the FingerprintAuth plugin
     if(cordova.platformId === "android"){Fingerprint.show(object, successCbFingerPrintAuth, errorCbFingerPrintAuth);}
     // if the device is ios call the touchid plugin 
-    if(cordova.platformId === "ios")touchid.authenticate(successCallback, errorCallback, object.dialogMessage);
+    if(cordova.platformId === "ios")touchid.authenticate(successCallback, errorCallback, object.description);
 };
 
 FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fixed bug we had on iOS regarding the Message to show in the biometric prompt. We were trying to obtain `object.dialogMessage` which doesn't exist in `object`. Switched it to `object.description` which is where the Message comes in.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1683

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [x] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested builds on MABS 8 and iOS 15 device.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/27646996/176148392-e63b4e43-eb55-4b06-88aa-add14407d91d.png)



## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
