### PR TITLE
RMET-2652 ::: Return more error information on touch id checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The changes documented here do not include those from the original repository.
 ## Unreleased
 
 ## 05-12-2024
-- [Android] Breaking Change - Return error information in callback
+- Breaking Change - Return error information in callback
 
 ## [3.1.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+
+## 05-12-2024
+- [Android] Breaking Change - Return error information in callback
+
 ## [3.1.8]
 
 ## 04-12-2024

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#fix/RMET-2652/biometrics-error-messages" />
+        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS6" />
     </platform>
 
     <platform name="ios">

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS6" />
+        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#fix/RMET-2652/biometrics-error-messages" />
     </platform>
 
     <platform name="ios">

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -70,7 +70,7 @@ FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {
     }
 
     function isAvailableError(error) {
-      errorCallback(-1);
+      errorCallback(error);
     }
 
     // if the device is android call the Fingerprint plugin

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -30,7 +30,7 @@ FingerPrint.prototype.isAvailable = function (successCallback, errorCallback) {
   }
 
   function isAvailableError(error) {
-    errorCallback(-1);
+    errorCallback(error);
   }
   // if the device is android call the Fingerprint plugin
   if(cordova.platformId === "android")Fingerprint.isAvailable(isAvailableSuccess, isAvailableError);
@@ -70,7 +70,7 @@ FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {
     }
 
     function isAvailableError(error) {
-      errorCallback(-1);
+      errorCallback(error);
     }
 
     // if the device is android call the Fingerprint plugin

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -70,7 +70,7 @@ FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {
     }
 
     function isAvailableError(error) {
-      errorCallback(error);
+      errorCallback(-1);
     }
 
     // if the device is android call the Fingerprint plugin


### PR DESCRIPTION
## Description

Currently we are returning a constant error integer - "-1" - regardless of the error returned by checking availability / biometrics type. This doesn't allow for any flexibility in showing different error messages, even though they were already being returned by Android and iOS.

This PR fixes it by actually returning the error body - similar to what happens in other cordova plugins.

## Context

- https://outsystemsrd.atlassian.net/browse/RMET-2652
- Also see https://github.com/OutSystems/cordova-plugin-fingerprint-aio/pull/17

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [x] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [X] JavaScript

## Tests

Test the Touch ID Sample app, in both Android and iOS

- If a different error message is displayed when a user has no fingerprint/biometrics configured in the phone
- If when there is a fingerprint/biometrics configured, the plugin still works as intended.



## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
