### PR TITLE
RMET-3663 :: Compatibility with Capacitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+package-lock.json
+.idea
+src/android/.project
+src/android/.gradle
+src/android/.settings
+
+.DS_Store
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## [4.1.0]
 
 ## 02-05-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+## 02-05-2025
+
+- Unified cordova plugins for Android and iOS, removing the dependencies on `cordova-plugin-fingerprint-aio` and `cordova-plugin-touchid`
+- [Android] Fix `AndroidManifest.xml` changes in `plugin.xml` to be compatible with Capacitor.
+
 ## [4.0.0]
 
 ## 05-12-2024

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@
   - iOS
   - Android
 
-## Dependencies 
+## Credits 
 
-  - cordova-plugin-fingerprint-aio
-  - cordova-plugin-touchid
+The native source code was based from other GitHub repositories:
+
+  - For Android: https://github.com/OutSystems/cordova-plugin-fingerprint-aio - Forked from [NiklasMerz](https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio) (MIT License).
+  - For iOS: https://github.com/OutSystems/cordova-plugin-touchid - Forked from [leecrossley](https://github.com/leecrossley/cordova-plugin-touchid).
 
 ## Installation
   - Run the following command:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-plugin-fingerprint",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Cordova FingerPrint Plugin",
   "cordova": {
     "id": "outsystems-plugin-fingerprint",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Cordova FingerPrint Plugin",
   "cordova": {
     "id": "outsystems-plugin-fingerprint",
-    "platforms": []
+    "platforms": [
+      "android",
+      "ios"
+    ]
   },
   "repository": {
     "type": "git",
@@ -15,12 +18,16 @@
     "device",
     "ecosystem:cordova"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
+  "devDependencies": {
+    "cordova-plugin-xml": "^0.1.2"
+  },
+  "engines": {
+    "cordovaDependencies": {
+      ">=3.0.0": {
+        "cordova-android": ">=8.0.0"
+      }
     }
-  ],
+  },
   "author": "OutSystems",
   "license": "Apache 2.0",
   "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="outsystems-plugin-fingerprint"
-    version="4.0.0">
+    version="4.1.0">
     <name>fingerprint</name>
     <description>Cordova FingerPrint Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,12 +32,12 @@
             </feature>
         </config-file>
       
-        <config-file target="AndroidManifest.xml" parent="/*">
+        <edit-config file="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.USE_BIOMETRIC" />
             <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="application">
+        <edit-config file="AndroidManifest.xml" parent="application">
             <activity
                 android:name="de.niklasmerz.cordova.biometric.BiometricActivity"
                 android:theme="@style/TransparentTheme"

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,15 +11,55 @@
     
     <engines>
         <engine name="cordova" version=">=3.0.0" />
+        <engine name="cordova-android" version=">=8.0.0" />
     </engines>
+
     <js-module src="www/FingerPrint.js" name="FingerPrint">
         <clobbers target="fingerprint" />
     </js-module>
 
 
     <platform name="android">
-        <dependency id="cordova-plugin-fingerprint-aio" url="https://github.com/OutSystems/cordova-plugin-fingerprint-aio.git#4.0.1-OS6" />
+        <config-file target="config.xml" parent="/*">
+            <platform name="android">
+                <preference name="AndroidXEnabled" value="true" />
+            </platform>
+        </config-file>
+
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Fingerprint">
+                <param name="android-package" value="de.niklasmerz.cordova.biometric.Fingerprint"/>
+            </feature>
+        </config-file>
+      
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+            <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+        </config-file>
+
+        <config-file target="AndroidManifest.xml" parent="application">
+            <activity
+                android:name="de.niklasmerz.cordova.biometric.BiometricActivity"
+                android:theme="@style/TransparentTheme"
+                android:exported="false" />
+        </config-file>
+      
+        <framework src="src/android/build.gradle" custom="true" type="gradleReference"/>
+        <resource-file src="src/android/res/biometric_activity.xml" target="res/layout/biometric_activity.xml" />
+        <resource-file src="src/android/res/styles.xml" target="res/values/biometric-styles.xml" />
+        <source-file src="src/android/PromptInfo.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/BiometricActivity.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/BiometricActivityType.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/Fingerprint.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/PluginError.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/Args.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/CryptographyManager.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/CryptographyManagerImpl.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/EncryptedData.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/CryptoException.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
+        <source-file src="src/android/KeyInvalidatedException.java" target-dir="src/de/niklasmerz/cordova/biometric"/>
     </platform>
+
 
     <platform name="ios">
         <!-- Usage description of the FaceID, mandatory since iOS 10 -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,12 +32,12 @@
             </feature>
         </config-file>
       
-        <edit-config file="AndroidManifest.xml" parent="/*">
+        <edit-config target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.USE_BIOMETRIC" />
             <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
         </edit-config>
 
-        <edit-config file="AndroidManifest.xml" parent="application">
+        <edit-config target="AndroidManifest.xml" parent="application">
             <activity
                 android:name="de.niklasmerz.cordova.biometric.BiometricActivity"
                 android:theme="@style/TransparentTheme"

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,14 +35,14 @@
         <edit-config file="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.USE_BIOMETRIC" />
             <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
-        </config-file>
+        </edit-config>
 
         <edit-config file="AndroidManifest.xml" parent="application">
             <activity
                 android:name="de.niklasmerz.cordova.biometric.BiometricActivity"
                 android:theme="@style/TransparentTheme"
                 android:exported="false" />
-        </config-file>
+        </edit-config>
       
         <framework src="src/android/build.gradle" custom="true" type="gradleReference"/>
         <resource-file src="src/android/res/biometric_activity.xml" target="res/layout/biometric_activity.xml" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -67,6 +67,15 @@
         <config-file target="*-Info.plist" parent="NSFaceIDUsageDescription">
             <string>$FACEID_USAGE_DESCRIPTION</string>
         </config-file>
-        <dependency id="cordova-plugin-touchid" url="https://github.com/OutSystems/cordova-plugin-touchid.git#0.4.0-OS2" />
+
+        <config-file target="config.xml" parent="/*">
+            <feature name="TouchID">
+                <param name="ios-package" value="TouchID" />
+            </feature>
+        </config-file>
+        <header-file src="src/ios/TouchID.h" />
+        <source-file src="src/ios/TouchID.m" />
+        <framework src="LocalAuthentication.framework" />
+        <framework src="Security.framework" />
     </platform>
 </plugin>

--- a/src/android/Args.java
+++ b/src/android/Args.java
@@ -1,0 +1,59 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Args {
+    private static final String TAG = "ARGS";
+    private JSONArray jsonArray;
+    private JSONObject argsObject;
+
+    Args(JSONArray jsonArray) {
+        this.jsonArray = jsonArray;
+    }
+
+    public Boolean getBoolean(String name, Boolean defaultValue) {
+        try {
+            if (getArgsObject().has(name)){
+                return getArgsObject().getBoolean(name);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Can't parse '" + name + "'. Default will be used.", e);
+        }
+        return defaultValue;
+    }
+
+    public String getString(String name, String defaultValue) {
+        try {
+            if (getArgsObject().optString(name) != null
+                && !getArgsObject().optString(name).isEmpty()){
+                return getArgsObject().getString(name);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Can't parse '" + name + "'. Default will be used.", e);
+        }
+        return defaultValue;
+    }
+
+    public Integer getInteger(String name, Integer defaultValue) {
+        try {
+            if (getArgsObject().has(name)){
+                return getArgsObject().getInt(name);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Can't parse '" + name + "'. Default will be used.", e);
+        }
+        return defaultValue;
+    }
+
+    private JSONObject getArgsObject() throws JSONException {
+        if (this.argsObject != null) {
+            return this.argsObject;
+        }
+        this.argsObject = jsonArray.getJSONObject(0);
+        return this.argsObject;
+    }
+}

--- a/src/android/BiometricActivity.java
+++ b/src/android/BiometricActivity.java
@@ -1,0 +1,256 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.app.Activity;
+import android.app.KeyguardManager;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.biometric.BiometricPrompt;
+import androidx.core.content.ContextCompat;
+
+import java.util.concurrent.Executor;
+
+import javax.crypto.Cipher;
+
+public class BiometricActivity extends AppCompatActivity {
+
+    private static final int REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS = 2;
+    private PromptInfo mPromptInfo;
+    private CryptographyManager mCryptographyManager;
+    private static final String SECRET_KEY = "__aio_secret_key";
+    private BiometricPrompt mBiometricPrompt;
+    private int numFailedAttempts = 0;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setTitle(null);
+        int layout = getResources()
+                .getIdentifier("biometric_activity", "layout", getPackageName());
+        setContentView(layout);
+
+        if (savedInstanceState != null) {
+            return;
+        }
+        
+
+        mPromptInfo = new PromptInfo.Builder(getIntent().getExtras()).build();
+        mCryptographyManager = new CryptographyManagerImpl();
+        final Handler handler = new Handler(Looper.getMainLooper());
+        Executor executor = handler::post;
+        mBiometricPrompt = new BiometricPrompt(this, executor, mAuthenticationCallback);
+        try {
+            authenticate();
+        } catch (CryptoException e) {
+            finishWithError(e);
+        } catch (Exception e) {
+            finishWithError(PluginError.BIOMETRIC_UNKNOWN_ERROR, e.getMessage());
+        }
+    }
+
+    private void authenticate() throws CryptoException {
+        switch (mPromptInfo.getType()) {
+          case JUST_AUTHENTICATE:
+            justAuthenticate();
+            return;
+          case REGISTER_SECRET:
+            authenticateToEncrypt(mPromptInfo.invalidateOnEnrollment());
+            return;
+          case LOAD_SECRET:
+            authenticateToDecrypt();
+            return;
+        }
+        throw new CryptoException(PluginError.BIOMETRIC_ARGS_PARSING_FAILED);
+    }
+
+    private void authenticateToEncrypt(boolean invalidateOnEnrollment) throws CryptoException {
+        if (mPromptInfo.getSecret() == null) {
+            throw new CryptoException(PluginError.BIOMETRIC_ARGS_PARSING_FAILED);
+        }
+        Cipher cipher = mCryptographyManager
+                .getInitializedCipherForEncryption(SECRET_KEY, invalidateOnEnrollment, this);
+        mBiometricPrompt.authenticate(createPromptInfo(), new BiometricPrompt.CryptoObject(cipher));
+    }
+
+    private void justAuthenticate() {
+        mBiometricPrompt.authenticate(createPromptInfo());
+    }
+
+    private void authenticateToDecrypt() throws CryptoException {
+        byte[] initializationVector = EncryptedData.loadInitializationVector(this);
+        Cipher cipher = mCryptographyManager
+                .getInitializedCipherForDecryption(SECRET_KEY, initializationVector, this);
+        mBiometricPrompt.authenticate(createPromptInfo(), new BiometricPrompt.CryptoObject(cipher));
+    }
+
+    private BiometricPrompt.PromptInfo createPromptInfo() {
+        BiometricPrompt.PromptInfo.Builder promptInfoBuilder = new BiometricPrompt.PromptInfo.Builder()
+                .setTitle(mPromptInfo.getTitle())
+                .setSubtitle(mPromptInfo.getSubtitle())
+                .setConfirmationRequired(mPromptInfo.getConfirmationRequired())
+                .setDescription(mPromptInfo.getDescription());
+
+        if (mPromptInfo.isDeviceCredentialAllowed()
+                && mPromptInfo.getType() == BiometricActivityType.JUST_AUTHENTICATE) {
+            promptInfoBuilder.setDeviceCredentialAllowed(true);
+        } else {
+            promptInfoBuilder.setNegativeButtonText(mPromptInfo.getCancelButtonTitle());
+        }
+        return promptInfoBuilder.build();
+    }
+
+    private BiometricPrompt.AuthenticationCallback mAuthenticationCallback =
+            new BiometricPrompt.AuthenticationCallback() {
+
+                @Override
+                public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
+                    super.onAuthenticationError(errorCode, errString);
+                    onError(errorCode, errString);
+                }
+
+                @Override
+                public void onAuthenticationSucceeded(@NonNull BiometricPrompt.AuthenticationResult result) {
+                    numFailedAttempts = 0;
+                    super.onAuthenticationSucceeded(result);
+                    try {
+                        finishWithSuccess(result.getCryptoObject());
+                    } catch (CryptoException e) {
+                        finishWithError(e);
+                    }
+                }
+
+                @Override
+                public void onAuthenticationFailed() {
+                    super.onAuthenticationFailed();
+                    numFailedAttempts++;
+                    if(numFailedAttempts >= mPromptInfo.getMaxAttempts()) {
+                        onError(PluginError.BIOMETRIC_LOCKED_OUT.getValue(), PluginError.BIOMETRIC_LOCKED_OUT.getMessage());
+                        mBiometricPrompt.cancelAuthentication();
+                        numFailedAttempts = 0;
+                    }
+                }
+            };
+
+
+    // TODO: remove after fix https://issuetracker.google.com/issues/142740104
+    private void showAuthenticationScreen() {
+        KeyguardManager keyguardManager = ContextCompat
+                .getSystemService(this, KeyguardManager.class);
+        if (keyguardManager == null
+                || android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+        if (keyguardManager.isKeyguardSecure()) {
+            Intent intent = keyguardManager
+                    .createConfirmDeviceCredentialIntent(mPromptInfo.getTitle(), mPromptInfo.getDescription());
+            this.startActivityForResult(intent, REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS);
+        } else {
+            // Show a message that the user hasn't set up a lock screen.
+            finishWithError(PluginError.BIOMETRIC_SCREEN_GUARD_UNSECURED);
+        }
+    }
+
+    // TODO: remove after fix https://issuetracker.google.com/issues/142740104
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS) {
+            if (resultCode == Activity.RESULT_OK) {
+                finishWithSuccess();
+            } else {
+                finishWithError(PluginError.BIOMETRIC_PIN_OR_PATTERN_DISMISSED);
+            }
+        }
+    }
+
+    private void onError(int errorCode, @NonNull CharSequence errString) {
+
+        switch (errorCode)
+        {
+            case BiometricPrompt.ERROR_USER_CANCELED:
+            case BiometricPrompt.ERROR_CANCELED:
+                finishWithError(PluginError.BIOMETRIC_DISMISSED);
+                return;
+            case BiometricPrompt.ERROR_NEGATIVE_BUTTON:
+                // TODO: remove after fix https://issuetracker.google.com/issues/142740104
+                if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P && mPromptInfo.isDeviceCredentialAllowed()) {
+                    showAuthenticationScreen();
+                    return;
+                }
+                finishWithError(PluginError.BIOMETRIC_DISMISSED);
+                break;
+            case BiometricPrompt.ERROR_LOCKOUT:
+                finishWithError(PluginError.BIOMETRIC_LOCKED_OUT.getValue(), errString.toString());
+                break;
+            case BiometricPrompt.ERROR_LOCKOUT_PERMANENT:
+                finishWithError(PluginError.BIOMETRIC_LOCKED_OUT_PERMANENT.getValue(), errString.toString());
+                break;
+            default:
+                finishWithError(errorCode, errString.toString());
+        }
+    }
+
+    private void finishWithSuccess() {
+        setResult(RESULT_OK);
+        finish();
+    }
+
+    private void finishWithSuccess(BiometricPrompt.CryptoObject cryptoObject) throws CryptoException {
+        Intent intent = null;
+        switch (mPromptInfo.getType()) {
+          case REGISTER_SECRET:
+            encrypt(cryptoObject);
+            break;
+          case LOAD_SECRET:
+            intent = getDecryptedIntent(cryptoObject);
+            break;
+        }
+        if (intent == null) {
+            setResult(RESULT_OK);
+        } else {
+            setResult(RESULT_OK, intent);
+        }
+        finish();
+    }
+
+    private void encrypt(BiometricPrompt.CryptoObject cryptoObject) throws CryptoException {
+        String text = mPromptInfo.getSecret();
+        EncryptedData encryptedData = mCryptographyManager.encryptData(text, cryptoObject.getCipher());
+        encryptedData.save(this);
+    }
+
+    private Intent getDecryptedIntent(BiometricPrompt.CryptoObject cryptoObject) throws CryptoException {
+        byte[] ciphertext = EncryptedData.loadCiphertext(this);
+        String secret = mCryptographyManager.decryptData(ciphertext, cryptoObject.getCipher());
+        if (secret != null) {
+            Intent intent = new Intent();
+            intent.putExtra(PromptInfo.SECRET_EXTRA, secret);
+            return intent;
+        }
+        return null;
+    }
+
+    private void finishWithError(CryptoException e) {
+        finishWithError(e.getError().getValue(), e.getMessage());
+    }
+
+    private void finishWithError(PluginError error) {
+        finishWithError(error.getValue(), error.getMessage());
+    }
+
+    private void finishWithError(PluginError error, String message) {
+        finishWithError(error.getValue(), message);
+    }
+
+    private void finishWithError(int code, String message) {
+        Intent data = new Intent();
+        data.putExtra("code", code);
+        data.putExtra("message", message);
+        setResult(RESULT_CANCELED, data);
+        finish();
+    }
+}

--- a/src/android/BiometricActivityType.java
+++ b/src/android/BiometricActivityType.java
@@ -1,0 +1,26 @@
+package de.niklasmerz.cordova.biometric;
+
+public enum BiometricActivityType {
+    JUST_AUTHENTICATE(1),
+    REGISTER_SECRET(2),
+    LOAD_SECRET(3);
+
+    private int value;
+
+    BiometricActivityType(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static BiometricActivityType fromValue(int val) {
+        for (BiometricActivityType type : values()) {
+            if (type.getValue() == val) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/src/android/CryptoException.java
+++ b/src/android/CryptoException.java
@@ -1,0 +1,26 @@
+package de.niklasmerz.cordova.biometric;
+
+class CryptoException extends Exception {
+    private PluginError error;
+
+    CryptoException(String message, Exception cause) {
+        this(PluginError.BIOMETRIC_UNKNOWN_ERROR, message, cause);
+    }
+
+    CryptoException(PluginError error) {
+        this(error, error.getMessage(), null);
+    }
+
+    CryptoException(PluginError error, Exception cause) {
+        this(error, error.getMessage(), cause);
+    }
+
+    private CryptoException(PluginError error, String message, Exception cause) {
+        super(message, cause);
+        this.error = error;
+    }
+
+    public PluginError getError() {
+        return error;
+    }
+}

--- a/src/android/CryptographyManager.java
+++ b/src/android/CryptographyManager.java
@@ -1,0 +1,31 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.content.Context;
+
+import javax.crypto.Cipher;
+
+interface CryptographyManager {
+
+    /**
+     * This method first gets or generates an instance of SecretKey and then initializes the Cipher
+     * with the key. The secret key uses [ENCRYPT_MODE][Cipher.ENCRYPT_MODE] is used.
+     */
+    Cipher getInitializedCipherForEncryption(String keyName, boolean invalidateOnEnrollment, Context context) throws CryptoException;
+
+    /**
+     * This method first gets or generates an instance of SecretKey and then initializes the Cipher
+     * with the key. The secret key uses [DECRYPT_MODE][Cipher.DECRYPT_MODE] is used.
+     */
+    Cipher getInitializedCipherForDecryption(String keyName, byte[] initializationVector, Context context) throws CryptoException;
+
+    /**
+     * The Cipher created with [getInitializedCipherForEncryption] is used here
+     */
+    EncryptedData encryptData(String plaintext, Cipher cipher) throws CryptoException;
+
+    /**
+     * The Cipher created with [getInitializedCipherForDecryption] is used here
+     */
+    String decryptData(byte[] ciphertext, Cipher cipher) throws CryptoException;
+
+}

--- a/src/android/CryptographyManagerImpl.java
+++ b/src/android/CryptographyManagerImpl.java
@@ -1,0 +1,170 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.content.Context;
+import android.os.Build;
+import android.security.KeyPairGeneratorSpec;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyPermanentlyInvalidatedException;
+import android.security.keystore.KeyProperties;
+import androidx.annotation.RequiresApi;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.security.auth.x500.X500Principal;
+
+class CryptographyManagerImpl implements CryptographyManager {
+
+    private static final int KEY_SIZE = 256;
+    private static final String ANDROID_KEYSTORE = "AndroidKeyStore";
+    private static final String ENCRYPTION_PADDING = "NoPadding"; // KeyProperties.ENCRYPTION_PADDING_NONE
+    private static final String ENCRYPTION_ALGORITHM = "AES"; // KeyProperties.KEY_ALGORITHM_AES
+    private static final String KEY_ALGORITHM_AES = "AES"; // KeyProperties.KEY_ALGORITHM_AES
+    private static final String ENCRYPTION_BLOCK_MODE = "GCM"; // KeyProperties.BLOCK_MODE_GCM
+
+    private Cipher getCipher() throws NoSuchPaddingException, NoSuchAlgorithmException {
+        String transformation = ENCRYPTION_ALGORITHM + "/" + ENCRYPTION_BLOCK_MODE + "/" + ENCRYPTION_PADDING;
+        return Cipher.getInstance(transformation);
+    }
+
+    private SecretKey getOrCreateSecretKey(String keyName, boolean invalidateOnEnrollment, Context context) throws CryptoException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return getOrCreateSecretKeyNew(keyName, invalidateOnEnrollment);
+        } else {
+            return getOrCreateSecretKeyOld(keyName, context);
+        }
+    }
+
+    private SecretKey getOrCreateSecretKeyOld(String keyName, Context context) throws CryptoException {
+        Calendar start = Calendar.getInstance();
+        Calendar end = Calendar.getInstance();
+        end.add(Calendar.YEAR, 1);
+        try {
+            KeyPairGeneratorSpec keySpec = new KeyPairGeneratorSpec.Builder(context)
+                    .setAlias(keyName)
+                    .setSubject(new X500Principal("CN=FINGERPRINT_AIO ," +
+                            " O=FINGERPRINT_AIO" +
+                            " C=World"))
+                    .setSerialNumber(BigInteger.ONE)
+                    .setStartDate(start.getTime())
+                    .setEndDate(end.getTime())
+                    .build();
+            KeyGenerator kg = KeyGenerator.getInstance(KEY_ALGORITHM_AES, ANDROID_KEYSTORE);
+            kg.init(keySpec);
+            return kg.generateKey();
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private SecretKey getOrCreateSecretKeyNew(String keyName, boolean invalidateOnEnrollment) throws CryptoException {
+        try {
+            // If Secretkey was previously created for that keyName, then grab and return it.
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEYSTORE);
+            keyStore.load(null); // Keystore must be loaded before it can be accessed
+
+
+            SecretKey key = (SecretKey) keyStore.getKey(keyName, null);
+            if (key != null) {
+                return key;
+            }
+
+            // if you reach here, then a new SecretKey must be generated for that keyName
+            KeyGenParameterSpec.Builder keyGenParamsBuilder = new KeyGenParameterSpec.Builder(keyName,
+                    KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(KEY_SIZE)
+                    .setUserAuthenticationRequired(true);
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                keyGenParamsBuilder.setInvalidatedByBiometricEnrollment(invalidateOnEnrollment);
+            }
+
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(KEY_ALGORITHM_AES,
+                    ANDROID_KEYSTORE);
+            keyGenerator.init(keyGenParamsBuilder.build());
+
+            return keyGenerator.generateKey();
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Cipher getInitializedCipherForEncryption(String keyName, boolean invalidateOnEnrollment, Context context) throws CryptoException {
+        try {
+            Cipher cipher = getCipher();
+            SecretKey secretKey = getOrCreateSecretKey(keyName, invalidateOnEnrollment, context);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+            return cipher;
+        } catch (Exception e) {
+            try {
+                handleException(e, keyName);
+            } catch (KeyInvalidatedException kie) {
+                return getInitializedCipherForEncryption(keyName, invalidateOnEnrollment, context);
+            }
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+
+    private void handleException(Exception e, String keyName) throws CryptoException {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                && e instanceof KeyPermanentlyInvalidatedException) {
+            removeKey(keyName);
+            throw new KeyInvalidatedException();
+        }
+    }
+
+    @Override
+    public Cipher getInitializedCipherForDecryption(String keyName, byte[] initializationVector, Context context) throws CryptoException {
+        try {
+            Cipher cipher = getCipher();
+            SecretKey secretKey = getOrCreateSecretKey(keyName, true, context);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, initializationVector));
+            return cipher;
+        } catch (Exception e) {
+            handleException(e, keyName);
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+
+    private void removeKey(String keyName) throws CryptoException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEYSTORE);
+            keyStore.load(null); // Keystore must be loaded before it can be accessed
+            keyStore.deleteEntry(keyName);
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public EncryptedData encryptData(String plaintext, Cipher cipher) throws CryptoException {
+        try {
+            byte[] ciphertext = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+            return new EncryptedData(ciphertext, cipher.getIV());
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String decryptData(byte[] ciphertext, Cipher cipher) throws CryptoException {
+        try {
+            byte[] plaintext = cipher.doFinal(ciphertext);
+            return new String(plaintext, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new CryptoException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/android/EncryptedData.java
+++ b/src/android/EncryptedData.java
@@ -1,0 +1,47 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Base64;
+
+class EncryptedData {
+
+    private static final String CIPHERTEXT_KEY_NAME = "__biometric-aio-ciphertext";
+    private static final String IV_KEY_NAME = "__biometric-aio-iv";
+
+    private byte[] ciphertext;
+    private byte[] initializationVector;
+
+    EncryptedData(byte[] ciphertext, byte[] initializationVector) {
+        this.ciphertext = ciphertext;
+        this.initializationVector = initializationVector;
+    }
+
+    static byte[] loadInitializationVector(Context context) throws CryptoException {
+        return load(IV_KEY_NAME, context);
+    }
+
+    static byte[] loadCiphertext(Context context) throws CryptoException {
+        return load(CIPHERTEXT_KEY_NAME, context);
+    }
+
+    void save(Context context) {
+        save(IV_KEY_NAME, initializationVector, context);
+        save(CIPHERTEXT_KEY_NAME, ciphertext, context);
+    }
+
+    private void save(String key, byte[] value, Context context) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        preferences.edit()
+                .putString(key, Base64.encodeToString(value, Base64.DEFAULT))
+                .apply();
+    }
+
+    private static byte[] load(String key, Context context) throws CryptoException {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        String res = preferences.getString(key, null);
+        if (res == null) throw new CryptoException(PluginError.BIOMETRIC_NO_SECRET_FOUND);
+        return Base64.decode(res, Base64.DEFAULT);
+    }
+}

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -1,0 +1,197 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+
+
+import androidx.biometric.BiometricManager;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Fingerprint extends CordovaPlugin {
+
+    private static final String TAG = "Fingerprint";
+    private static final int REQUEST_CODE_BIOMETRIC = 1;
+
+    private CallbackContext mCallbackContext = null;
+    private PromptInfo.Builder mPromptInfoBuilder;
+
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        Log.v(TAG, "Init Fingerprint");
+        mPromptInfoBuilder = new PromptInfo.Builder(
+            this.getApplicationLabel(cordova.getActivity())
+        );
+    }
+
+    public boolean execute(final String action, JSONArray args, CallbackContext callbackContext) {
+
+        this.mCallbackContext = callbackContext;
+        Log.v(TAG, "Fingerprint action: " + action);
+
+        if ("authenticate".equals(action)) {
+            executeAuthenticate(args);
+            return true;
+
+        } else if ("registerBiometricSecret".equals(action)) {
+             executeRegisterBiometricSecret(args);
+             return true;
+
+         } else if ("loadBiometricSecret".equals(action)) {
+             executeLoadBiometricSecret(args);
+             return true;
+
+         } else if ("isAvailable".equals(action)) {
+            executeIsAvailable();
+            return true;
+
+        }
+        return false;
+    }
+
+    private void executeIsAvailable() {
+        PluginError error = canAuthenticate();
+        if (error != null) {
+            sendError(error);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
+            sendSuccess("biometric");
+        } else {
+            sendSuccess("finger");
+        }
+    }
+    private void executeRegisterBiometricSecret(JSONArray args) {
+        // should at least contains the secret
+        if (args == null) {
+            sendError(PluginError.BIOMETRIC_ARGS_PARSING_FAILED);
+            return;
+        }
+        this.runBiometricActivity(args, BiometricActivityType.REGISTER_SECRET);
+    }
+
+    private void executeLoadBiometricSecret(JSONArray args) {
+        this.runBiometricActivity(args, BiometricActivityType.LOAD_SECRET);
+    }
+
+    private void executeAuthenticate(JSONArray args) {
+        this.runBiometricActivity(args, BiometricActivityType.JUST_AUTHENTICATE);
+    }
+
+    private void runBiometricActivity(JSONArray args, BiometricActivityType type) {
+        PluginError error = canAuthenticate();
+        if (error != null) {
+            sendError(error);
+            return;
+        }
+        cordova.getActivity().runOnUiThread(() -> {
+            mPromptInfoBuilder.parseArgs(args, type);
+            Intent intent = new Intent(cordova.getActivity().getApplicationContext(), BiometricActivity.class);
+            intent.putExtras(mPromptInfoBuilder.build().getBundle());
+            this.cordova.startActivityForResult(this, intent, REQUEST_CODE_BIOMETRIC);
+        });
+        PluginResult pluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
+        pluginResult.setKeepCallback(true);
+        this.mCallbackContext.sendPluginResult(pluginResult);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        super.onActivityResult(requestCode, resultCode, intent);
+        if (requestCode != REQUEST_CODE_BIOMETRIC) {
+            return;
+        }
+        if (resultCode != Activity.RESULT_OK) {
+            sendError(intent);
+            return;
+        }
+        sendSuccess(intent);
+    }
+
+    private void sendSuccess(Intent intent) {
+        if (intent != null && intent.getExtras() != null) {
+            sendSuccess(intent.getExtras().getString(PromptInfo.SECRET_EXTRA));
+        } else {
+            sendSuccess("biometric_success");
+        }
+    }
+
+    private void sendError(Intent intent) {
+        if (intent != null) {
+            Bundle extras = intent.getExtras();
+            sendError(extras.getInt("code"), extras.getString("message"));
+        } else {
+            sendError(PluginError.BIOMETRIC_DISMISSED);
+        }
+    }
+
+    private PluginError canAuthenticate() {
+        int error = BiometricManager.from(cordova.getContext()).canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK);
+
+        switch (error) {
+            case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
+            case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
+                return PluginError.BIOMETRIC_HARDWARE_NOT_SUPPORTED;
+            case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
+                return PluginError.BIOMETRIC_NOT_ENROLLED;
+            case BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED:
+                return PluginError.BIOMETRIC_SECURITY_VULNERABILITY;
+            case BiometricManager.BIOMETRIC_SUCCESS:
+                return null;
+            case BiometricManager.BIOMETRIC_STATUS_UNKNOWN:
+            default:
+                return PluginError.BIOMETRIC_UNKNOWN_ERROR;
+        }
+    }
+
+    private void sendError(int code, String message) {
+        JSONObject resultJson = new JSONObject();
+        try {
+            resultJson.put("code", code);
+            resultJson.put("message", message);
+
+            PluginResult result = new PluginResult(PluginResult.Status.ERROR, resultJson);
+            result.setKeepCallback(true);
+            if(Fingerprint.this.mCallbackContext != null){
+                cordova.getActivity().runOnUiThread(() ->
+                        Fingerprint.this.mCallbackContext.sendPluginResult(result));
+            }
+            else{
+                Log.e(TAG, code + ":" + message);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, e.getMessage(), e);
+        }
+    }
+
+    private void sendError(PluginError error) {
+        sendError(error.getValue(), error.getMessage());
+    }
+
+    private void sendSuccess(String message) {
+        Log.e(TAG, message);
+        cordova.getActivity().runOnUiThread(() ->
+                this.mCallbackContext.success(message));
+    }
+
+    private String getApplicationLabel(Context context) {
+        try {
+            PackageManager packageManager = context.getPackageManager();
+            ApplicationInfo app = packageManager
+                    .getApplicationInfo(context.getPackageName(), 0);
+            return packageManager.getApplicationLabel(app).toString();
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+    }
+}

--- a/src/android/KeyInvalidatedException.java
+++ b/src/android/KeyInvalidatedException.java
@@ -1,0 +1,7 @@
+package de.niklasmerz.cordova.biometric;
+
+class KeyInvalidatedException extends CryptoException {
+    KeyInvalidatedException() {
+        super(PluginError.BIOMETRIC_NO_SECRET_FOUND);
+    }
+}

--- a/src/android/PluginError.java
+++ b/src/android/PluginError.java
@@ -1,0 +1,42 @@
+package de.niklasmerz.cordova.biometric;
+
+public enum PluginError {
+
+    BIOMETRIC_UNKNOWN_ERROR(-100, "An unknown error occurred."),
+    BIOMETRIC_AUTHENTICATION_FAILED(-102, "Authentication failed."),
+    BIOMETRIC_HARDWARE_NOT_SUPPORTED(-104, "Biometrics is not supported on this hardware."),
+    BIOMETRIC_NOT_ENROLLED(-106, "Biometrics is not configured."),
+    BIOMETRIC_DISMISSED(-108, "Biometric prompt was dismissed by user."),
+    BIOMETRIC_PIN_OR_PATTERN_DISMISSED(-109, "Device credentials prompt was dismissed by user."),
+    BIOMETRIC_SCREEN_GUARD_UNSECURED(-110,
+            "Go to 'Settings -> Security -> Screenlock' to set up a lock screen."),
+    BIOMETRIC_LOCKED_OUT(-111, "Too many failed attempts. Try again later."),
+    BIOMETRIC_LOCKED_OUT_PERMANENT(-112, "Too many failed attempts. You need to use your device credentials to unlock."),
+    BIOMETRIC_NO_SECRET_FOUND(-113, "No secret found. Unable to decrypt using biometrics."),
+    BIOMETRIC_ARGS_PARSING_FAILED(-115, "Invalid arguments were sent."),
+
+    BIOMETRIC_SECURITY_VULNERABILITY(-116,
+            "A security vulnerability has been discovered with one or more hardware sensors. The affected sensor(s) are unavailable until a security update has addressed the issue."),
+    ;
+
+    private int value;
+    private String message;
+
+    PluginError(int value) {
+        this.value = value;
+        this.message = this.name();
+    }
+
+    PluginError(int value, String message) {
+        this.value = value;
+        this.message = message;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/android/PromptInfo.java
+++ b/src/android/PromptInfo.java
@@ -1,0 +1,139 @@
+package de.niklasmerz.cordova.biometric;
+
+import android.os.Bundle;
+
+import org.json.JSONArray;
+
+class PromptInfo {
+
+    private static final String DISABLE_BACKUP = "disableBackup";
+    private static final String TITLE = "title";
+    private static final String SUBTITLE = "subtitle";
+    private static final String DESCRIPTION = "description";
+    private static final String MAX_ATTEMPTS = "maxAttempts";
+    private static final String FALLBACK_BUTTON_TITLE = "fallbackButtonTitle";
+    private static final String CANCEL_BUTTON_TITLE = "cancelButtonTitle";
+    private static final String CONFIRMATION_REQUIRED = "confirmationRequired";
+    private static final String INVALIDATE_ON_ENROLLMENT = "invalidateOnEnrollment";
+    private static final String SECRET = "secret";
+    private static final String BIOMETRIC_ACTIVITY_TYPE = "biometricActivityType";
+
+    static final String SECRET_EXTRA = "secret";
+
+    private Bundle bundle = new Bundle();
+
+    Bundle getBundle() {
+        return bundle;
+    }
+
+    String getTitle() {
+        return bundle.getString(TITLE);
+    }
+
+    String getSubtitle() {
+        return bundle.getString(SUBTITLE);
+    }
+
+    String getDescription() {
+        return bundle.getString(DESCRIPTION);
+    }
+
+    Integer getMaxAttempts(){ return bundle.getInt(MAX_ATTEMPTS); }
+
+    boolean isDeviceCredentialAllowed() {
+        return !bundle.getBoolean(DISABLE_BACKUP);
+    }
+
+    String getFallbackButtonTitle() {
+        return bundle.getString(FALLBACK_BUTTON_TITLE);
+    }
+
+    String getCancelButtonTitle() {
+        return bundle.getString(CANCEL_BUTTON_TITLE);
+    }
+
+    boolean getConfirmationRequired() {
+        return bundle.getBoolean(CONFIRMATION_REQUIRED);
+    }
+
+    String getSecret() {
+        return bundle.getString(SECRET);
+    }
+
+    boolean invalidateOnEnrollment() {
+        return bundle.getBoolean(INVALIDATE_ON_ENROLLMENT);
+    }
+
+    BiometricActivityType getType() {
+        return BiometricActivityType.fromValue(bundle.getInt(BIOMETRIC_ACTIVITY_TYPE));
+    }
+
+    public static final class Builder {
+        private static final String TAG = "PromptInfo.Builder";
+        private Bundle bundle;
+        private boolean disableBackup = false;
+        private String title;
+        private String subtitle = null;
+        private String description = null;
+        private Integer maxAttempts = 5;
+        private String fallbackButtonTitle = "Use backup";
+        private String cancelButtonTitle = "Cancel";
+        private boolean confirmationRequired = true;
+        private boolean invalidateOnEnrollment = false;
+        private String secret = null;
+        private BiometricActivityType type = null;
+
+        Builder(String applicationLabel) {
+            if (applicationLabel == null) {
+                title = "Biometric Sign On";
+            } else {
+                title = applicationLabel + " Biometric Sign On";
+            }
+        }
+
+        Builder(Bundle bundle) {
+            this.bundle = bundle;
+        }
+
+        public PromptInfo build() {
+            PromptInfo promptInfo = new PromptInfo();
+
+            if (this.bundle != null) {
+                promptInfo.bundle = bundle;
+                return promptInfo;
+            }
+
+            Bundle bundle = new Bundle();
+            bundle.putString(SUBTITLE, this.subtitle);
+            bundle.putString(TITLE, this.title);
+            bundle.putString(DESCRIPTION, this.description);
+            bundle.putInt(MAX_ATTEMPTS, this.maxAttempts);
+            bundle.putString(FALLBACK_BUTTON_TITLE, this.fallbackButtonTitle);
+            bundle.putString(CANCEL_BUTTON_TITLE, this.cancelButtonTitle);
+            bundle.putString(SECRET, this.secret);
+            bundle.putBoolean(DISABLE_BACKUP, this.disableBackup);
+            bundle.putBoolean(CONFIRMATION_REQUIRED, this.confirmationRequired);
+            bundle.putBoolean(INVALIDATE_ON_ENROLLMENT, this.invalidateOnEnrollment);
+            bundle.putInt(BIOMETRIC_ACTIVITY_TYPE, this.type.getValue());
+            promptInfo.bundle = bundle;
+
+            return promptInfo;
+        }
+
+        void parseArgs(JSONArray jsonArgs, BiometricActivityType type) {
+            this.type = type;
+
+            Args args = new Args(jsonArgs);
+            disableBackup = args.getBoolean(DISABLE_BACKUP, disableBackup);
+            title = args.getString(TITLE, title);
+            subtitle = args.getString(SUBTITLE, subtitle);
+            description = args.getString(DESCRIPTION, description);
+            maxAttempts = args.getInteger(MAX_ATTEMPTS, maxAttempts);
+            fallbackButtonTitle = args.getString(FALLBACK_BUTTON_TITLE, "Use Backup");
+            cancelButtonTitle = args.getString(CANCEL_BUTTON_TITLE, "Cancel");
+            confirmationRequired = args.getBoolean(CONFIRMATION_REQUIRED, confirmationRequired);
+            invalidateOnEnrollment = args.getBoolean(INVALIDATE_ON_ENROLLMENT, false);
+            secret = args.getString(SECRET, null);
+        }
+    }
+}

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation "androidx.biometric:biometric:1.1.0"
+}
+
+android {
+    packagingOptions {
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+    }
+}

--- a/src/android/res/biometric_activity.xml
+++ b/src/android/res/biometric_activity.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent">
+
+</FrameLayout>

--- a/src/android/res/styles.xml
+++ b/src/android/res/styles.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2019 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<resources>
+    <style name="TransparentTheme" parent="Theme.AppCompat">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>

--- a/src/ios/TouchID.h
+++ b/src/ios/TouchID.h
@@ -1,0 +1,14 @@
+//
+//  TouchID.h
+//  Copyright (c) 2014 Lee Crossley - http://ilee.co.uk
+//
+
+#import <Cordova/CDVPlugin.h>
+
+@interface TouchID : CDVPlugin
+
+- (void) authenticate:(CDVInvokedUrlCommand*)command;
+- (void) checkSupport:(CDVInvokedUrlCommand*)command;
+- (void) checkBiometry:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -1,0 +1,142 @@
+//
+//  TouchID.m
+//  Copyright (c) 2014 Lee Crossley - http://ilee.co.uk
+//
+
+#import "TouchID.h"
+
+#import <LocalAuthentication/LocalAuthentication.h>
+
+@implementation TouchID
+
+- (void) authenticate:(CDVInvokedUrlCommand*)command;
+{
+    NSString *text = [command.arguments objectAtIndex:0];
+
+    __block CDVPluginResult* pluginResult = nil;
+
+    if (NSClassFromString(@"LAContext") != nil)
+    {
+        LAContext *laContext = [[LAContext alloc] init];
+        NSError *authError = nil;
+
+        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&authError])
+        {
+            [laContext evaluatePolicy:LAPolicyDeviceOwnerAuthentication localizedReason:text reply:^(BOOL success, NSError *error)
+             {
+                 if (success)
+                 {
+                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+                 }
+                 else
+                 {
+                     NSString *errorCode = nil;
+                     switch (error.code) {
+                         case LAErrorAuthenticationFailed:
+                             errorCode = @"authenticationFailed";
+                             break;
+                         case LAErrorUserCancel:
+                             errorCode = @"userCancel";
+                             break;
+                         case LAErrorUserFallback:
+                             errorCode = @"userFallback";
+                             break;
+                         case LAErrorSystemCancel:
+                             errorCode = @"systemCancel";
+                             break;
+                         case LAErrorPasscodeNotSet:
+                             errorCode = @"passcodeNotSet";
+                             break;
+                         case LAErrorTouchIDNotAvailable:
+                             errorCode = @"touchIDNotAvailable";
+                             break;
+                         case LAErrorTouchIDNotEnrolled:
+                             errorCode = @"touchIDNotEnrolled";
+                             break;
+                         default:
+                             errorCode = @"unknown";
+                             break;
+                     }
+                     
+                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:errorCode];
+                 }
+
+                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+             }];
+        }
+        else
+        {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[authError localizedDescription]];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }
+    }
+    else
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }
+}
+
+- (void) checkSupport:(CDVInvokedUrlCommand*)command;
+{
+
+    __block CDVPluginResult* pluginResult = nil;
+
+    if (NSClassFromString(@"LAContext") != nil)
+    {
+        LAContext *laContext = [[LAContext alloc] init];
+        NSError *authError = nil;
+
+        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&authError])
+        {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        }
+        else
+        {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[authError localizedDescription]];
+        }
+    }
+    else
+    {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) checkBiometry:(CDVInvokedUrlCommand *)command;
+{
+    __block CDVPluginResult* pluginResult = nil;
+    
+    if (NSClassFromString(@"LAContext") != nil)
+    {
+        LAContext *laContext = [[LAContext alloc] init];
+        //No biometry
+        int biometryType = -1;
+        
+        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:nil]) {
+            if (@available(iOS 11.0, *)) {
+                if (laContext.biometryType == LABiometryTypeFaceID) {
+                    //FaceID
+                    biometryType = 2;
+                }
+                else {
+                    //TouchID
+                    biometryType = 1;
+                }
+                
+            }
+            else {
+                //Before iOS 11 only existed TouchID
+                biometryType = 1;
+            }
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:biometryType];
+        }
+        else {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsInt:biometryType];
+        }
+    }
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+@end

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -40,10 +40,10 @@ FingerPrint.prototype.isAvailable = function (successCallback, errorCallback) {
   }
 
   if(getPlatformId() === "android") {
-    cordova.exec(isAvailableSuccess, isAvailableError, "fingerprint", "isAvailable", []);
+    cordova.exec(isAvailableSuccess, isAvailableError, "Fingerprint", "isAvailable", []);
   }
   else if(getPlatformId() === "ios") {
-    cordova.exec(successCallback, errorCallback, "fingerprint", "checkSupport", []);
+    cordova.exec(successCallback, errorCallback, "TouchID", "checkSupport", []);
   }
 };
 
@@ -57,13 +57,13 @@ FingerPrint.prototype.authenticate = function (successCallback, errorCallback, o
 			errorCallback(message);
     };
     if(getPlatformId() === "android") {
-      cordova.exec(successCbFingerPrintAuth, errorCbFingerPrintAuth, "fingerprint", "authenticate", [object]);
+      cordova.exec(successCbFingerPrintAuth, errorCbFingerPrintAuth, "Fingerprint", "authenticate", [object]);
     }
     else if(getPlatformId() === "ios") {
       if (!object.description) {
         object.description = "Please authenticate via TouchID to proceed";
       }
-      cordova.exec(successCallback, errorCallback, "fingerprint", "authenticate", [object.description]);
+      cordova.exec(successCallback, errorCallback, "TouchID", "authenticate", [object.description]);
     }
 };
 
@@ -88,10 +88,10 @@ FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {
     }
 
     if(getPlatformId() === "android") {
-      cordova.exec(isAvailableSuccess, isAvailableError, "fingerprint", "isAvailable", []);
+      cordova.exec(isAvailableSuccess, isAvailableError, "Fingerprint", "isAvailable", []);
     }
     else if(getPlatformId() === "ios") {
-      cordova.exec(successCallback, errorCallback, "fingerprint", "checkBiometry");
+      cordova.exec(successCallback, errorCallback, "TouchID", "checkBiometry");
     }
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR has the following changes to make the cordova plugin (and the Outsystems Plugin that consumes it) to be compatible in Capacitor builds.

1. The dependencies on other cordova plugins were removed, and the native source code was migrated to this repository - the Java / Objective-C code remained exactly the same. Because those other plugins were only used as dependencies for this plugin, there's no issues in doing this change.
2. Fixed the `AndroidManifest.xml` changes in `plugin.xml` to use `edit-config` instead of `config-file` (because the former is supported on Capacitor and the latter is not).
3. The Info.plist change is done on Outsystems side (Plugin extensibility configurations), as Capacitor builds do not support `<edit-config` on `Info.plist`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3663

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [x] JavaScript

## Tests

Manual tests with MABS 11 and MABS 12 builds of "TouchIdDemoApp" in ODC, on both Android and iOS

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
