### PR TITLE
 RMET-4883 :: added support for BIOMETRIC_STRONG 

### DIFF
--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -40,6 +40,7 @@ public class Fingerprint extends CordovaPlugin {
 
         this.mCallbackContext = callbackContext;
         Log.v(TAG, "Fingerprint action: " + action);
+        Log.v(TAG, "Fingerprint args: " + args.toString());
 
         if ("authenticate".equals(action)) {
             executeAuthenticate(args);

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -40,7 +40,6 @@ public class Fingerprint extends CordovaPlugin {
 
         this.mCallbackContext = callbackContext;
         Log.v(TAG, "Fingerprint action: " + action);
-        
         if ("authenticate".equals(action)) {
             executeAuthenticate(args);
             return true;

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -185,6 +185,7 @@ public class Fingerprint extends CordovaPlugin {
     }
 
     private void sendSuccess(String message) {
+        Log.e(TAG, message);
         cordova.getActivity().runOnUiThread(() ->
                 this.mCallbackContext.success(message));
     }

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -168,16 +168,12 @@ public class Fingerprint extends CordovaPlugin {
 
             PluginResult result = new PluginResult(PluginResult.Status.ERROR, resultJson);
             result.setKeepCallback(true);
-            if (cordova.getActivity() != null) {
-                if(Fingerprint.this.mCallbackContext != null){
-                    cordova.getActivity().runOnUiThread(() ->
-                            Fingerprint.this.mCallbackContext.sendPluginResult(result));
-                }
-                else{
-                    Log.e(TAG, code + ":" + message);
-                }
-            } else {
-                Log.e(TAG, "Cordova activity does not exist.");
+            if(Fingerprint.this.mCallbackContext != null){
+                cordova.getActivity().runOnUiThread(() ->
+                        Fingerprint.this.mCallbackContext.sendPluginResult(result));
+            }
+            else{
+                Log.e(TAG, code + ":" + message);
             }
         } catch (JSONException e) {
             Log.e(TAG, e.getMessage(), e);

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -40,8 +40,7 @@ public class Fingerprint extends CordovaPlugin {
 
         this.mCallbackContext = callbackContext;
         Log.v(TAG, "Fingerprint action: " + action);
-        Log.v(TAG, "Fingerprint args: " + args.toString());
-
+        
         if ("authenticate".equals(action)) {
             executeAuthenticate(args);
             return true;

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -88,13 +88,12 @@ public class Fingerprint extends CordovaPlugin {
         this.runBiometricActivity(args, BiometricActivityType.JUST_AUTHENTICATE);
     }
 
-    private boolean determineStrongBiometricsRequired(BiometricActivityType type) {
-        return type == BiometricActivityType.REGISTER_SECRET || type == BiometricActivityType.LOAD_SECRET;
-    }
-
     private void runBiometricActivity(JSONArray args, BiometricActivityType type) {
-        boolean requireStrongBiometrics = determineStrongBiometricsRequired(type);
+        boolean requireStrongBiometricsFromArgs = new Args(args).getBoolean("requireStrongBiometrics", false);
+
+        boolean requireStrongBiometrics = requireStrongBiometricsFromArgs || type == BiometricActivityType.REGISTER_SECRET || type == BiometricActivityType.LOAD_SECRET;
         PluginError error = canAuthenticate(requireStrongBiometrics);
+
         if (error != null) {
             sendError(error);
             return;

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -143,15 +143,20 @@ public class Fingerprint extends CordovaPlugin {
 
     private PluginError canAuthenticate(boolean requireStrongBiometrics) {
         int error = BiometricManager.from(cordova.getContext()).canAuthenticate(requireStrongBiometrics ? BiometricManager.Authenticators.BIOMETRIC_STRONG : BiometricManager.Authenticators.BIOMETRIC_WEAK);
+        
         switch (error) {
             case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
             case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
                 return PluginError.BIOMETRIC_HARDWARE_NOT_SUPPORTED;
             case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
                 return PluginError.BIOMETRIC_NOT_ENROLLED;
+            case BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED:
+                return PluginError.BIOMETRIC_SECURITY_VULNERABILITY;
             case BiometricManager.BIOMETRIC_SUCCESS:
-            default:
                 return null;
+            case BiometricManager.BIOMETRIC_STATUS_UNKNOWN:
+            default:
+                return PluginError.BIOMETRIC_UNKNOWN_ERROR;
         }
     }
 

--- a/www/FingerPrint.js
+++ b/www/FingerPrint.js
@@ -18,7 +18,7 @@ FingerPrint.prototype.BIOMETRIC_TYPE_COMMON = 2;
 FingerPrint.prototype.BIOMETRIC_TYPE_NONE = 3;
 
 // method to check is the touch id option is available in the device
-FingerPrint.prototype.isAvailable = function (successCallback, errorCallback) {
+FingerPrint.prototype.isAvailable = function (successCallback, errorCallback, object) {
   // success callback function for android 
   function isAvailableSuccess(result) {
 
@@ -40,7 +40,7 @@ FingerPrint.prototype.isAvailable = function (successCallback, errorCallback) {
   }
 
   if(getPlatformId() === "android") {
-    cordova.exec(isAvailableSuccess, isAvailableError, "Fingerprint", "isAvailable", []);
+    cordova.exec(isAvailableSuccess, isAvailableError, "Fingerprint", "isAvailable", [object]);
   }
   else if(getPlatformId() === "ios") {
     cordova.exec(successCallback, errorCallback, "TouchID", "checkSupport", []);
@@ -67,7 +67,7 @@ FingerPrint.prototype.authenticate = function (successCallback, errorCallback, o
     }
 };
 
-FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {
+FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback, object) {
   
     function isAvailableSuccess(result) {
         switch (result) {
@@ -88,7 +88,7 @@ FingerPrint.prototype.checkBiometry = function(successCallback, errorCallback) {
     }
 
     if(getPlatformId() === "android") {
-      cordova.exec(isAvailableSuccess, isAvailableError, "Fingerprint", "isAvailable", []);
+      cordova.exec(isAvailableSuccess, isAvailableError, "Fingerprint", "isAvailable", [object]);
     }
     else if(getPlatformId() === "ios") {
       cordova.exec(successCallback, errorCallback, "TouchID", "checkBiometry");


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR introduces support for distinguishing between strong and weak biometric authentication on Android by adding a new optional parameter: `requireStrongBiometrics`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4883

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tests performed in ODC and O11, using the sample app in our tenant.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
