### PR TITLE
fix(android): fall back to device PIN when no biometrics are enrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [4.2.1]
+
+## 14-05-2026
+
+- [Android] Fix `authenticate` failing with `BIOMETRIC_NOT_ENROLLED` ("Biometrics is not configured") on devices that have a PIN/pattern/password but no biometrics enrolled. The plugin now falls back to the system device-credential prompt when `disableBackup` is not set, matching the iOS behaviour.
+
 ## [4.2.0]
 
 ## 29-12-2025

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-plugin-fingerprint",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Cordova FingerPrint Plugin",
   "cordova": {
     "id": "outsystems-plugin-fingerprint",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="outsystems-plugin-fingerprint"
-    version="4.2.0">
+    version="4.2.1">
     <name>fingerprint</name>
     <description>Cordova FingerPrint Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/BiometricActivity.java
+++ b/src/android/BiometricActivity.java
@@ -10,6 +10,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.core.content.ContextCompat;
 
@@ -78,7 +79,19 @@ public class BiometricActivity extends AppCompatActivity {
     }
 
     private void justAuthenticate() {
+        // BiometricPrompt's own PIN fallback is unreliable when no biometric is enrolled
+        // (issuetracker.google.com/142740104), so launch the device-credential prompt directly.
+        if (mPromptInfo.isDeviceCredentialAllowed() && !canAuthenticateWithBiometrics()) {
+            showAuthenticationScreen();
+            return;
+        }
         mBiometricPrompt.authenticate(createPromptInfo());
+    }
+
+    private boolean canAuthenticateWithBiometrics() {
+        int result = BiometricManager.from(this)
+                .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK);
+        return result == BiometricManager.BIOMETRIC_SUCCESS;
     }
 
     private void authenticateToDecrypt() throws CryptoException {

--- a/src/android/BiometricActivity.java
+++ b/src/android/BiometricActivity.java
@@ -79,9 +79,12 @@ public class BiometricActivity extends AppCompatActivity {
     }
 
     private void justAuthenticate() {
-        // BiometricPrompt's own PIN fallback is unreliable when no biometric is enrolled
-        // (issuetracker.google.com/142740104), so launch the device-credential prompt directly.
-        if (mPromptInfo.isDeviceCredentialAllowed() && !canAuthenticateWithBiometrics()) {
+        // On Android 10 and below, BiometricPrompt's PIN fallback doesn't fire when no biometric
+        // is enrolled (issuetracker.google.com/142740104, also tracked in RMET-3897). Launch the
+        // device-credential prompt directly on those versions; Android 11+ handles it natively.
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q
+                && mPromptInfo.isDeviceCredentialAllowed()
+                && !canAuthenticateWithBiometrics()) {
             showAuthenticationScreen();
             return;
         }

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -62,10 +62,8 @@ public class Fingerprint extends CordovaPlugin {
     }
 
     private void executeIsAvailable(JSONArray args) {
-        Args parsedArgs = new Args(args);
-        boolean requireStrongBiometrics = parsedArgs.getBoolean("requireStrongBiometrics", false);
-        boolean allowDeviceCredential = !parsedArgs.getBoolean("disableBackup", false);
-        PluginError error = canAuthenticate(requireStrongBiometrics, allowDeviceCredential);
+        boolean requireStrongBiometrics = new Args(args).getBoolean("requireStrongBiometrics", false);
+        PluginError error = canAuthenticate(requireStrongBiometrics, false);
         if (error != null) {
             sendError(error);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
@@ -149,9 +147,9 @@ public class Fingerprint extends CordovaPlugin {
         int authenticator = requireStrongBiometrics
                 ? BiometricManager.Authenticators.BIOMETRIC_STRONG
                 : BiometricManager.Authenticators.BIOMETRIC_WEAK;
-        int error = BiometricManager.from(cordova.getContext()).canAuthenticate(authenticator);
+        int result = BiometricManager.from(cordova.getContext()).canAuthenticate(authenticator);
 
-        if (error == BiometricManager.BIOMETRIC_SUCCESS) {
+        if (result == BiometricManager.BIOMETRIC_SUCCESS) {
             return null;
         }
 
@@ -160,7 +158,7 @@ public class Fingerprint extends CordovaPlugin {
             return null;
         }
 
-        switch (error) {
+        switch (result) {
             case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
             case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
                 return PluginError.BIOMETRIC_HARDWARE_NOT_SUPPORTED;

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -1,5 +1,6 @@
 package de.niklasmerz.cordova.biometric;
 
+import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -61,8 +62,10 @@ public class Fingerprint extends CordovaPlugin {
     }
 
     private void executeIsAvailable(JSONArray args) {
-        boolean requireStrongBiometrics = new Args(args).getBoolean("requireStrongBiometrics", false);
-        PluginError error = canAuthenticate(requireStrongBiometrics);
+        Args parsedArgs = new Args(args);
+        boolean requireStrongBiometrics = parsedArgs.getBoolean("requireStrongBiometrics", false);
+        boolean allowDeviceCredential = !parsedArgs.getBoolean("disableBackup", false);
+        PluginError error = canAuthenticate(requireStrongBiometrics, allowDeviceCredential);
         if (error != null) {
             sendError(error);
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P){
@@ -89,10 +92,13 @@ public class Fingerprint extends CordovaPlugin {
     }
 
     private void runBiometricActivity(JSONArray args, BiometricActivityType type) {
-        boolean requireStrongBiometricsFromArgs = new Args(args).getBoolean("requireStrongBiometrics", false);
+        Args parsedArgs = new Args(args);
+        boolean requireStrongBiometricsFromArgs = parsedArgs.getBoolean("requireStrongBiometrics", false);
+        boolean isCryptoFlow = type == BiometricActivityType.REGISTER_SECRET || type == BiometricActivityType.LOAD_SECRET;
 
-        boolean requireStrongBiometrics = requireStrongBiometricsFromArgs || type == BiometricActivityType.REGISTER_SECRET || type == BiometricActivityType.LOAD_SECRET;
-        PluginError error = canAuthenticate(requireStrongBiometrics);
+        boolean requireStrongBiometrics = requireStrongBiometricsFromArgs || isCryptoFlow;
+        boolean allowDeviceCredential = !isCryptoFlow && !parsedArgs.getBoolean("disableBackup", false);
+        PluginError error = canAuthenticate(requireStrongBiometrics, allowDeviceCredential);
 
         if (error != null) {
             sendError(error);
@@ -139,9 +145,21 @@ public class Fingerprint extends CordovaPlugin {
         }
     }
 
-    private PluginError canAuthenticate(boolean requireStrongBiometrics) {
-        int error = BiometricManager.from(cordova.getContext()).canAuthenticate(requireStrongBiometrics ? BiometricManager.Authenticators.BIOMETRIC_STRONG : BiometricManager.Authenticators.BIOMETRIC_WEAK);
-        
+    private PluginError canAuthenticate(boolean requireStrongBiometrics, boolean allowDeviceCredential) {
+        int authenticator = requireStrongBiometrics
+                ? BiometricManager.Authenticators.BIOMETRIC_STRONG
+                : BiometricManager.Authenticators.BIOMETRIC_WEAK;
+        int error = BiometricManager.from(cordova.getContext()).canAuthenticate(authenticator);
+
+        if (error == BiometricManager.BIOMETRIC_SUCCESS) {
+            return null;
+        }
+
+        // Biometrics unavailable, but the device PIN can still authenticate the user.
+        if (allowDeviceCredential && isDeviceSecure()) {
+            return null;
+        }
+
         switch (error) {
             case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
             case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
@@ -150,12 +168,16 @@ public class Fingerprint extends CordovaPlugin {
                 return PluginError.BIOMETRIC_NOT_ENROLLED;
             case BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED:
                 return PluginError.BIOMETRIC_SECURITY_VULNERABILITY;
-            case BiometricManager.BIOMETRIC_SUCCESS:
-                return null;
             case BiometricManager.BIOMETRIC_STATUS_UNKNOWN:
             default:
                 return PluginError.BIOMETRIC_UNKNOWN_ERROR;
         }
+    }
+
+    private boolean isDeviceSecure() {
+        KeyguardManager km = (KeyguardManager) cordova.getContext()
+                .getSystemService(Context.KEYGUARD_SERVICE);
+        return km != null && km.isDeviceSecure();
     }
 
     private void sendError(int code, String message) {


### PR DESCRIPTION
> [!WARNING]
> I used Claude to assist with the implementation

## What

`authenticate()` was returning `BIOMETRIC_NOT_ENROLLED` on Android
when the device had a PIN but no fingerprint or face enrolled. iOS
already falls back to the device passcode in this case; Android now
does the same.

## Changes

- `canAuthenticate` accepts the call when the device has a secure
  keyguard and the caller hasn't set `disableBackup: true`.
- `BiometricActivity` launches the system PIN prompt directly when
  no biometric is enrolled, since `BiometricPrompt`'s built-in
  fallback is unreliable in that state (issuetracker.google.com/142740104).
- Crypto flows (`registerBiometricSecret` / `loadBiometricSecret`)
  are unchanged and still require a biometric.

## Testing

Validated on a Pixel 8 Pro (Android 16) with a minimal Cordova sample app & ODC.

- [x] Fingerprint + PIN, default args: biometric prompt with PIN fallback
- [x] Fingerprint + PIN, `disableBackup: true`: biometric only
- [x] Fingerprint + PIN, `requireStrongBiometrics: true`: strong only

### MABS Build
Press the "Connexion" button on a device with no biometrics configured. The proper fallback method should appear on the screen (PIN/Passcode/None).

OLD (see apk in ticket); https://outsystemsrd.atlassian.net/browse/RDINC-81715

FIXED: https://eng-mobile.outsystems.dev/apps/distributemobile?appid=818f0abc-68e7-4d4c-9a42-06f888be6ee2&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b

Resolves [RPM-6834](https://outsystemsrd.atlassian.net/browse/RPM-6834)

[RPM-6834]: https://outsystemsrd.atlassian.net/browse/RPM-6834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ